### PR TITLE
Use the same edit icon as other enrol plugins

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -85,7 +85,7 @@ class enrol_signup_plugin extends enrol_plugin {
         if (has_capability('enrol/signup:config', $context)) {
             $editlink = new moodle_url("/enrol/signup/edit.php", array('courseid' => $instance->courseid,
                         'id' => $instance->id));
-            $icons[] = $OUTPUT->action_icon($editlink, new pix_icon('i/edit', get_string('edit'),
+            $icons[] = $OUTPUT->action_icon($editlink, new pix_icon('t/edit', get_string('edit'),
                         'core', array('class' => 'icon')));
         }
 


### PR DESCRIPTION
A minor change to use the same edit icon as other enrol plugins.

Currently, the edit icon is a pencil in course enrolment settings. Other plugins use a wheel as describe in _get_action_icons()_ method in _lib/enrollib.php_.

Regards,
